### PR TITLE
[tcc-test] Modificações para simulação do TCC PECE 2024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ __debug_bin
 modules/fybrik-template/fybrik-template-0.0.0.tgz
 manager/testdata/**/*.crt
 manager/testdata/**/*.key
+charts/cert-manager
+secret.yaml
 
 pipeline/custom_*
 pipeline/vault_cre*

--- a/samples/assets/asset.yaml
+++ b/samples/assets/asset.yaml
@@ -1,0 +1,45 @@
+apiVersion: katalog.fybrik.io/v1alpha1
+kind: Asset
+metadata:
+  name: house-price-bd
+  namespace: fybrik-notebook-sample
+spec:
+  secretRef:
+    name: house-price-bd-secret
+    namespace: fybrik-notebook-sample
+  metadata:
+    name: Bangladesh House Prices
+    owner: tcc-data-mesh
+    geography: bd
+    tags:
+      Purpose.realestate: 'true'
+      Source.academic: 'true'
+    columns:
+    - name: Title
+    - name: Bedrooms
+    - name: Bathrooms
+    - name: Floor_no
+    - name: Occupancy_status
+    - name: Floor_area
+    - name: City
+      tags:
+        sensitive: "true"
+        category: "location"
+    - name: Price_in_taka
+      tags:
+        sensitive: "true"
+        category: "price"
+    - name: Location
+      tags:
+        sensitive: "true"
+        category: "location"
+  details:
+    dataFormat: csv
+    connection:
+      name: s3
+      s3:
+        endpoint: s3.sa-east-1.amazonaws.com
+        region: <region_name_AWS>
+        bucket: <bucket_name_AWS>
+        object_key: house_price_bd.csv
+  

--- a/samples/assets/dados/app-data.yaml
+++ b/samples/assets/dados/app-data.yaml
@@ -1,0 +1,19 @@
+apiVersion: app.fybrik.io/v1beta1
+kind: FybrikApplication
+metadata:
+  name: app-data
+  namespace: fybrik-notebook-sample
+spec:
+  appInfo:
+    intent: "read"
+  selector:
+    workloadSelector:
+      matchLabels:
+        app: nb-data
+        team: data
+  data:
+    - dataSetID: fybrik-notebook-sample/house-price-bd
+      requirements:
+        interface:
+          protocol: fybrik-arrow-flight
+          dataformat: csv

--- a/samples/assets/dados/nb-data.yaml
+++ b/samples/assets/dados/nb-data.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nb-data
+  namespace: fybrik-notebook-sample
+  labels:
+    app: nb-data
+    team: data
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nb-data
+  template:
+    metadata:
+      labels:
+        app: nb-data
+        team: data
+    spec:
+      containers:
+        - name: notebook
+          image: jupyter/base-notebook:latest
+          ports:
+            - containerPort: 8888

--- a/samples/assets/deploy-jupyters.yaml
+++ b/samples/assets/deploy-jupyters.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nb-data
+  namespace: fybrik-notebook-sample
+  labels:
+    app: nb-data
+    team: data
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nb-data
+      team: data
+  template:
+    metadata:
+      labels:
+        app: nb-data
+        team: data
+    spec:
+      containers:
+        - name: notebook
+          image: jupyter/minimal-notebook:python-3.11
+          ports:
+            - containerPort: 8888
+          env:
+            - name: JUPYTER_TOKEN
+              value: "tcc-token"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nb-marketing
+  namespace: fybrik-notebook-sample
+  labels:
+    app: nb-marketing
+    team: marketing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nb-marketing
+      team: marketing
+  template:
+    metadata:
+      labels:
+        app: nb-marketing
+        team: marketing
+    spec:
+      containers:
+        - name: notebook
+          image: jupyter/minimal-notebook:python-3.11
+          ports:
+            - containerPort: 8888
+          env:
+            - name: JUPYTER_TOKEN
+              value: "tcc-token"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nb-finance
+  namespace: fybrik-notebook-sample
+  labels:
+    app: nb-finance
+    team: finance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nb-finance
+      team: finance
+  template:
+    metadata:
+      labels:
+        app: nb-finance
+        team: finance
+    spec:
+      containers:
+        - name: notebook
+          image: jupyter/minimal-notebook:python-3.11
+          ports:
+            - containerPort: 8888
+          env:
+            - name: JUPYTER_TOKEN
+              value: "tcc-token"

--- a/samples/assets/financeiro/app-finance.yaml
+++ b/samples/assets/financeiro/app-finance.yaml
@@ -1,0 +1,19 @@
+apiVersion: app.fybrik.io/v1beta1
+kind: FybrikApplication
+metadata:
+  name: app-finance
+  namespace: fybrik-notebook-sample
+spec:
+  appInfo:
+    intent: "read"
+  selector:
+    workloadSelector:
+      matchLabels:
+        app: nb-finance
+        team: finance
+  data:
+    - dataSetID: fybrik-notebook-sample/house-price-bd
+      requirements:
+        interface:
+          protocol: fybrik-arrow-flight
+          dataformat: csv

--- a/samples/assets/financeiro/nb-finance.yaml
+++ b/samples/assets/financeiro/nb-finance.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nb-finance
+  namespace: fybrik-notebook-sample
+  labels:
+    app: nb-finance
+    team: finance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nb-finance
+  template:
+    metadata:
+      labels:
+        app: nb-finance
+        team: finance
+    spec:
+      containers:
+        - name: notebook
+          image: jupyter/base-notebook:latest
+          ports:
+            - containerPort: 8888

--- a/samples/assets/marketing/app-marketing.yaml
+++ b/samples/assets/marketing/app-marketing.yaml
@@ -1,0 +1,19 @@
+apiVersion: app.fybrik.io/v1beta1
+kind: FybrikApplication
+metadata:
+  name: app-marketing
+  namespace: fybrik-notebook-sample
+spec:
+  appInfo:
+    intent: "read"
+  selector:
+    workloadSelector:
+      matchLabels:
+        app: nb-marketing
+        team: marketing
+  data:
+    - dataSetID: fybrik-notebook-sample/house-price-bd
+      requirements:
+        interface:
+          protocol: fybrik-arrow-flight
+          dataformat: csv

--- a/samples/assets/marketing/nb-marketing.yaml
+++ b/samples/assets/marketing/nb-marketing.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nb-marketing
+  namespace: fybrik-notebook-sample
+  labels:
+    app: nb-marketing
+    team: marketing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nb-marketing
+  template:
+    metadata:
+      labels:
+        app: nb-marketing
+        team: marketing
+    spec:
+      containers:
+        - name: notebook
+          image: jupyter/base-notebook:latest
+          ports:
+            - containerPort: 8888

--- a/samples/assets/policy-redaction.rego
+++ b/samples/assets/policy-redaction.rego
@@ -1,0 +1,20 @@
+package dataapi.authz
+
+default allow = false
+
+# Usuário da área de dados tem acesso completo
+allow {
+    input.user_role == "dados"
+}
+
+# Usuário de marketing só pode acessar colunas que não sejam 'price_in_taka'
+allow {
+    input.user_role == "marketing"
+    not input.column == "price_in_taka"
+}
+
+# Usuário de financeiro só pode acessar colunas que não sejam 'city'
+allow {
+    input.user_role == "financeiro"
+    not input.column == "city"
+}

--- a/samples/assets/policy-redaction.rego
+++ b/samples/assets/policy-redaction.rego
@@ -1,20 +1,13 @@
 package dataapi.authz
 
-default allow = false
-
-# Usuário da área de dados tem acesso completo
-allow {
-    input.user_role == "dados"
+# Marketing: ocultar a coluna Price_in_taka
+verdict[{"action": {"name":"DeleteColumn", "columns": ["Price_in_taka"]}, "policy": "Ocultar Price_in_taka para marketing"}] {
+  input.action.actionType == "read"
+  input.context.workload.properties["team"] == "marketing"
 }
 
-# Usuário de marketing só pode acessar colunas que não sejam 'price_in_taka'
-allow {
-    input.user_role == "marketing"
-    not input.column == "price_in_taka"
-}
-
-# Usuário de financeiro só pode acessar colunas que não sejam 'city'
-allow {
-    input.user_role == "financeiro"
-    not input.column == "city"
+# Finance: ocultar a coluna City
+verdict[{"action": {"name":"DeleteColumn", "columns": ["City", "Location"]}, "policy": "Ocultar City para financeiro"}] {
+  input.action.actionType == "read"
+  input.context.workload.properties["team"] == "finance"
 }

--- a/samples/assets/secrets.yaml
+++ b/samples/assets/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: house-price-bd-secret
+  namespace: fybrik-notebook-sample
+type: Opaque
+stringData:
+  access_key: <access_key_AWS>
+  secret_key: <secret_key_AWS>


### PR DESCRIPTION
O presente PR tem como intuito evidenciar os arquivos criados para a utilização do Fybrik em ambiente local, no contexto do Trabalho de Conclusão de Curso (TCC) da estudante Tamy Takara Yatsu, do curso de Especialização em Engenharia de Dados e Big Data (PECE – Escola Politécnica da USP).

**Principais alterações**

- Adição dos manifests de deployments de Jupyter Notebooks (deploy-jupyters.yaml), representando as áreas de dados, marketing e financeiro.
- Criação dos FybrikApplications (app-data.yaml, app-marketing.yaml, app-finance.yaml) para cada área, vinculando workloads aos datasets.
- Inclusão do arquivo de políticas OPA (policy-redaction.rego) para mascarar/remover colunas sensíveis de acordo com o domínio de negócio.
- Configuração de asset.yaml e secrets.yaml para acesso controlado ao dataset no S3.

**Objetivo**
Demonstrar a separação por domínios de negócio e a aplicação de governança de dados em nível de coluna, utilizando o Fybrik integrado ao OPA, de forma prática e reprodutível em ambiente Kubernetes local